### PR TITLE
requiring correct exercise file

### DIFF
--- a/stage-2/module-pattern/exercise.js
+++ b/stage-2/module-pattern/exercise.js
@@ -17,7 +17,7 @@
  * |          |     |                |   |      |  |             |
  * | protocol |     |    domain      |   | path |  | querystring |
  */
-var UrlParser = (function () {
+var UrlParser = function() {
   // fill in ...
 
   return {
@@ -31,10 +31,9 @@ var UrlParser = (function () {
     path: null,
 
     // a function that takes a URL and returns its query string
-    query: null,
+    querystring: null
   };
-});
-
+};
 
 /*
  * Create a module that can support multiple instances (like in our example).
@@ -50,16 +49,15 @@ var UrlParser = (function () {
  *
  * exampleBuilder.
  */
-var createUrlBuilder = function (host) {
+var createUrlBuilder = function(host) {
   // fill in ...
 
-  var builder = function () {}
+  var builder = function() {};
 
   return builder;
 };
 
-
 module.exports = {
   UrlParser,
-  createUrlBuilder,
+  createUrlBuilder
 };

--- a/stage-2/module-pattern/exercise.test.js
+++ b/stage-2/module-pattern/exercise.test.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const tape = require('tape');
-const exercise = require('../../.solutions/stage-2/module-pattern/solution.js');
-// const exercise = require('./exercise.js');
+// const exercise = require('../../.solutions/stage-2/module-pattern/exercise.js');
+const exercise = require('./exercise.js');
 
-tape('Module Pattern', function (test) {
-  test.test('UrlParser', function (t) {
+tape('Module Pattern', function(test) {
+  test.test('UrlParser', function(t) {
     const { UrlParser } = exercise;
     const url = 'https://example.com/hello?foo=1&bar=2';
 
@@ -13,7 +13,11 @@ tape('Module Pattern', function (test) {
     t.equal(typeof UrlParser.protocol, 'function', 'Expect protocol method');
     t.equal(typeof UrlParser.domain, 'function', 'Expect domain method');
     t.equal(typeof UrlParser.path, 'function', 'Expect path method');
-    t.equal(typeof UrlParser.querystring, 'function', 'Expect querystring method');
+    t.equal(
+      typeof UrlParser.querystring,
+      'function',
+      'Expect querystring method'
+    );
 
     t.equal(UrlParser.protocol(url), 'https');
     t.equal(UrlParser.domain(url), 'example.com');
@@ -22,12 +26,16 @@ tape('Module Pattern', function (test) {
     t.end();
   });
 
-  test.test('createUrlBuilder', function (t) {
+  test.test('createUrlBuilder', function(t) {
     const { createUrlBuilder } = exercise;
     const host = 'https://example.com';
     const urlBuilder = createUrlBuilder(host);
 
-    t.equal(typeof urlBuilder, 'function', 'Expect URL builder to be a function');
+    t.equal(
+      typeof urlBuilder,
+      'function',
+      'Expect URL builder to be a function'
+    );
     t.equal(
       urlBuilder({ path: 'hello', query: { foo: 1, bar: 2 } }),
       `${host}/hello?foo=1&bar=2`,


### PR DESCRIPTION
Tests were previously all passing before any code had been written into the exercise, it was requiring the solutions.js not the exercise.js
The exercise also had a different key name for the querystring which was causing one test to fail.